### PR TITLE
use sqlite to store data used by the street command on disk

### DIFF
--- a/handler/sqlite.go
+++ b/handler/sqlite.go
@@ -30,7 +30,6 @@ func (s *Sqlite3) ReadNode(item gosmparse.Node) {
 
 	// ref, key, value
 	for key, value := range item.Tags {
-
 		_, err := s.Conn.Stmt.NodeTags.Exec(item.ID, key, value)
 		if err != nil {
 			log.Println(err)
@@ -54,7 +53,6 @@ func (s *Sqlite3) ReadWay(item gosmparse.Way) {
 
 	// ref, key, value
 	for key, value := range item.Tags {
-
 		_, err := s.Conn.Stmt.WayTags.Exec(item.ID, key, value)
 		if err != nil {
 			log.Println(err)
@@ -86,7 +84,6 @@ func (s *Sqlite3) ReadRelation(item gosmparse.Relation) {
 
 	// ref, key, value
 	for key, value := range item.Tags {
-
 		_, err := s.Conn.Stmt.RelationTags.Exec(item.ID, key, value)
 		if err != nil {
 			log.Println(err)

--- a/handler/streets.go
+++ b/handler/streets.go
@@ -9,7 +9,7 @@ import (
 // Streets - Streets
 type Streets struct {
 	TagWhitelist map[string]bool
-	Ways         []gosmparse.Way
+	DBHandler    *Sqlite3
 	NodeMask     *lib.Bitmask
 }
 
@@ -31,11 +31,11 @@ func (s *Streets) ReadWay(item gosmparse.Way) {
 		return
 	}
 
-	// remove all tags except for 'name' to conserve memory
+	// remove all tags except for 'name' to conserve storage space
 	item.Tags = map[string]string{"name": item.Tags["name"]}
 
-	// add way to slice
-	s.Ways = append(s.Ways, item)
+	// add way to database
+	s.DBHandler.ReadWay(item)
 
 	// store way refs in the node mask
 	for _, nodeid := range item.NodeIDs {

--- a/lib/temp.go
+++ b/lib/temp.go
@@ -1,0 +1,15 @@
+package lib
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+)
+
+// TempFileName generates a temporary filename for use in testing or whatever
+func TempFileName(prefix, suffix string) string {
+	randBytes := make([]byte, 16)
+	rand.Read(randBytes)
+	return filepath.Join(os.TempDir(), prefix+hex.EncodeToString(randBytes)+suffix)
+}

--- a/sqlite/connection.go
+++ b/sqlite/connection.go
@@ -14,6 +14,11 @@ type Connection struct {
 	Stmt *Statements
 }
 
+// GetDB - expose the underlying db object
+func (c *Connection) GetDB() *sql.DB {
+	return c.db
+}
+
 // Open - open connection and set up
 func (c *Connection) Open(path string) {
 	db, err := sql.Open("sqlite3", path)


### PR DESCRIPTION
The `streets` command has become more popular than I expected, with some people trying to use it to generate polyline extracts from very large PBF extracts, see https://github.com/missinglink/pbf/issues/12 & https://github.com/pelias/interpolation/issues/127

The `streets` command was only ever intended for use with extracts which can easily fit in memory, using it on larger extracts causes memory errors and crashes :(

This PR changes the way the data is stored, instead of storing it in-memory I'm storing it in a SQLite database in the temp directory.

Please note: it is still required to load all the street data in to memory in order to match & join street segments, so it's not a 'silver bullet', it does however allow me to convert `us-midwest-latest.osm.pbf` on my laptop without going to swap (16GB machine running a bunch of other stuff at the same time).

So the good news is that the RAM requirement is significantly reduced and the bad news is that the command is still bound by the available memory of the system.

There is a well tested alternative strategy for full planet polylines exports using the valhalla routing engine and documented here: https://github.com/pelias/polylines/wiki/Generating-polylines-from-Valhalla

I also changed the 'distance tolerance' which is used for matching adjacent linestrings to `0.0005` degrees (up from 0.0001 degrees), this means that lines broken by an intersection (< ~55 meters) will now be merged and a line segment spanning the intersection will be added.