### PR TITLE
xroads: export to CSV format for import into Pelias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine3.8 AS builder
+FROM golang:1.13.7-alpine3.11 AS builder
 
 WORKDIR "$GOPATH/src/github.com/missinglink/pbf"
 
@@ -9,6 +9,8 @@ COPY . "$GOPATH/src/github.com/missinglink/pbf"
 
 RUN go get && go build
 
-FROM alpine:3.8
+FROM alpine:3.11.3
 
 COPY --from=builder /go/src/github.com/missinglink/pbf/pbf /bin/
+
+ENTRYPOINT [ "pbf" ]

--- a/command/crossroads.go
+++ b/command/crossroads.go
@@ -88,7 +88,7 @@ func printCSVLine(csvWriter *csv.Writer, handler *handler.Xroads, nodeid int64, 
 		for j, wayID2 := range uniqueWayIds {
 			var name1 = handler.WayNames[wayID1]
 			var name2 = handler.WayNames[wayID2]
-			if j <= i || wayID1 == wayID2 || len(name1) == 0 || len(name2) == 0 {
+			if j <= i || wayID1 == wayID2 || name1 == name2 || len(name1) == 0 || len(name2) == 0 {
 				continue
 			}
 			err := csvWriter.Write([]string{

--- a/command/crossroads.go
+++ b/command/crossroads.go
@@ -1,12 +1,15 @@
 package command
 
 import (
+	"encoding/csv"
 	"fmt"
-	"sort"
-	"strings"
+	"log"
+	"os"
 	"sync"
 
+	"github.com/missinglink/gosmparse"
 	"github.com/missinglink/pbf/handler"
+	"github.com/missinglink/pbf/lib"
 	"github.com/missinglink/pbf/parser"
 	"github.com/missinglink/pbf/tags"
 
@@ -21,50 +24,85 @@ func Crossroads(c *cli.Context) error {
 
 	// stats handler
 	handler := &handler.Xroads{
-		TagWhiteList:  tags.Highway(),
-		WayNames:      make(map[string]string),
-		InvertedIndex: make(map[string][]string),
-		Mutex:         &sync.Mutex{},
+		TagWhiteList:         tags.Highway(),
+		IntersectionWaysMask: lib.NewBitMask(),
+		WayNames:             make(map[int64]string),
+		NodeMap:              make(map[int64][]int64),
+		Coords:               make(map[int64]*gosmparse.Node),
+		Mutex:                &sync.Mutex{},
 	}
 
-	// parse file
+	// parse file and compute all intersections
 	parser.Parse(handler)
 
-	// iterate over inverted index
-	for nodeid, wayids := range handler.InvertedIndex {
+	// remove any nodes which are members of less than two ways
+	handler.TrimNonIntersections()
 
-		// uniqify wayids
-		uniqueWayIds := uniqString(wayids)
-		if len(uniqueWayIds) > 1 {
+	// reset parser and make a second pass over the file
+	// to collect the node coordinates
+	parser.Reset()
+	handler.Pass++
+	parser.Parse(handler)
 
-			// generate way names
-			var names []string
-			sort.Strings(uniqueWayIds)
-			for _, wayid := range uniqueWayIds {
-				names = append(names, handler.WayNames[wayid])
-			}
+	// create a new CSV writer
+	csvWriter := csv.NewWriter(os.Stdout)
+	defer csvWriter.Flush()
 
-			// only unique ones
-			var uniqueNames = uniqString(names)
-			sort.Strings(uniqueNames)
-			if len(uniqueNames) > 1 {
-				fmt.Printf("http://openstreetmap.org/node/%-15v %v\n", nodeid, strings.Join(uniqueNames, " / "))
-			}
+	printCSVHeader(csvWriter)
+
+	// iterate over the nodes which represent an intersection
+	for nodeid, wayids := range handler.NodeMap {
+		if len(wayids) > 1 {
+
+			// write csv
+			printCSVLine(csvWriter, handler, nodeid, wayids)
 		}
 	}
 
 	return nil
 }
 
-// convenience func to uniq a set
-func uniqString(list []string) []string {
-	uniqueSet := make(map[string]bool)
-	for _, x := range list {
-		uniqueSet[x] = true
+// print the CSV header
+func printCSVHeader(csvWriter *csv.Writer) {
+	err := csvWriter.Write([]string{
+		"source",
+		"ID",
+		"layer",
+		"lat",
+		"lon",
+		"street",
+		"cross_street",
+	})
+	if err != nil {
+		fmt.Println(err)
 	}
-	result := make([]string, 0, len(uniqueSet))
-	for x := range uniqueSet {
-		result = append(result, x)
+}
+
+// print crossroad info as CSV line
+func printCSVLine(csvWriter *csv.Writer, handler *handler.Xroads, nodeid int64, uniqueWayIds []int64) {
+	var coords = handler.Coords[nodeid]
+
+	// generate one row per intersection
+	// (there may be multiple streets intersecting a single node)
+	for i, wayID1 := range uniqueWayIds {
+		for j, wayID2 := range uniqueWayIds {
+			var name1 = handler.WayNames[wayID1]
+			var name2 = handler.WayNames[wayID2]
+			if j <= i || wayID1 == wayID2 || len(name1) == 0 || len(name2) == 0 {
+				continue
+			}
+			err := csvWriter.Write([]string{
+				"osm",
+				fmt.Sprintf("w%d-n%d-w%d", wayID1, nodeid, wayID2),
+				"intersection",
+				fmt.Sprintf("%f", coords.Lat),
+				fmt.Sprintf("%f", coords.Lon),
+				name1,
+				name2,
+			})
+			if err != nil {
+				log.Println(err)
+			}
+		}
 	}
-	return result
 }

--- a/handler/xroads.go
+++ b/handler/xroads.go
@@ -1,59 +1,104 @@
 package handler
 
 import (
-	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/missinglink/gosmparse"
+	"github.com/missinglink/pbf/lib"
 )
 
 // Xroads - Xroads
 type Xroads struct {
-	TagWhiteList  map[string]bool
-	WayNames      map[string]string
-	InvertedIndex map[string][]string
-	Mutex         *sync.Mutex
+	Pass                 int64
+	TagWhiteList         map[string]bool
+	IntersectionWaysMask *lib.Bitmask
+	WayNames             map[int64]string
+	NodeMap              map[int64][]int64
+	Coords               map[int64]*gosmparse.Node
+	Mutex                *sync.Mutex
 }
 
 // ReadNode - called once per node
 func (x *Xroads) ReadNode(item gosmparse.Node) {
-	// noop
+	// skip unless this is the second pass over the file
+	if x.Pass != 1 {
+		return
+	}
+
+	if _, ok := x.NodeMap[item.ID]; ok {
+		x.Mutex.Lock()
+		x.Coords[item.ID] = &gosmparse.Node{
+			Lat: item.Lat,
+			Lon: item.Lon,
+		}
+		x.Mutex.Unlock()
+	}
 }
 
 // ReadWay - called once per way
 func (x *Xroads) ReadWay(item gosmparse.Way) {
+	// compute intersections on first pass
+	if x.Pass == 0 {
 
-	// must be valid highway tag
-	if _, ok := x.TagWhiteList[item.Tags["highway"]]; !ok {
-		return
+		// must be valid highway tag
+		if _, ok := x.TagWhiteList[item.Tags["highway"]]; !ok {
+			return
+		}
+
+		// store the way ids in an array with the nodeid as key
+		for _, nodeid := range item.NodeIDs {
+			x.Mutex.Lock()
+			x.NodeMap[nodeid] = appendUnique(x.NodeMap[nodeid], item.ID)
+			x.Mutex.Unlock()
+		}
 	}
 
-	// convert int64 to string
-	var wayIDString = strconv.FormatInt(item.ID, 10)
-
-	// get the best name from the tags
-	if val, ok := item.Tags["addr:street"]; ok {
-		x.Mutex.Lock()
-		x.WayNames[wayIDString] = val
-		x.Mutex.Unlock()
-	} else if val, ok := item.Tags["name"]; ok {
-		x.Mutex.Lock()
-		x.WayNames[wayIDString] = val
-		x.Mutex.Unlock()
-	} else {
-		return
-	}
-
-	// store the way ids in an array with the nodeid as key
-	for _, nodeid := range item.NodeIDs {
-		var nodeIDString = strconv.FormatInt(nodeid, 10)
-		x.Mutex.Lock()
-		x.InvertedIndex[nodeIDString] = append(x.InvertedIndex[nodeIDString], wayIDString)
-		x.Mutex.Unlock()
+	// only store names on second pass to save memory
+	// (after $IntersectionWaysMask has been populated with matches)
+	if x.Pass == 1 && x.IntersectionWaysMask.Has(item.ID) {
+		// get the best name from the tags
+		if val, ok := item.Tags["addr:street"]; ok {
+			x.Mutex.Lock()
+			x.WayNames[item.ID] = strings.TrimSpace(val)
+			x.Mutex.Unlock()
+		} else if val, ok := item.Tags["name"]; ok {
+			x.Mutex.Lock()
+			x.WayNames[item.ID] = strings.TrimSpace(val)
+			x.Mutex.Unlock()
+		} else {
+			return
+		}
 	}
 }
 
 // ReadRelation - called once per relation
 func (x *Xroads) ReadRelation(item gosmparse.Relation) {
 	// noop
+}
+
+// TrimNonIntersections - remove any nodes which have less than two ways
+func (x *Xroads) TrimNonIntersections() {
+	x.Mutex.Lock()
+	for nodeID, wayIDs := range x.NodeMap {
+		if len(wayIDs) < 2 {
+			delete(x.NodeMap, nodeID)
+		} else {
+			// insert all intersection way IDs in mask
+			for _, wayID := range wayIDs {
+				x.IntersectionWaysMask.Insert(wayID)
+			}
+		}
+	}
+	x.Mutex.Unlock()
+}
+
+// https://stackoverflow.com/a/9561388
+func appendUnique(slice []int64, i int64) []int64 {
+	for _, ele := range slice {
+		if ele == i {
+			return slice
+		}
+	}
+	return append(slice, i)
 }


### PR DESCRIPTION
This PR updates the `xroads` function to export a CSV file which is compatible with the Pelias [csv-importer](https://github.com/pelias/csv-importer).

I've had to make a few changes such as making two passes over the file in order to reduce memory requirements, I suspect that the full planet file can be processed on a dev laptop, since I'm trading CPU for memory that would likely take about (25mins x2) to parse the file and a minute or five to write the CSV out to disk.