### PR TITLE
Change intersection source name to `openstreetmap`

### DIFF
--- a/command/crossroads.go
+++ b/command/crossroads.go
@@ -110,7 +110,7 @@ func printCSVLines(csvWriter *csv.Writer, handler *handler.Xroads, nodeid int64,
 			}
 
 			err := csvWriter.Write([]string{
-				"osm",
+				"openstreetmap",
 				fmt.Sprintf("w%d-n%d-w%d", wayID1, nodeid, wayID2),
 				"intersection",
 				fmt.Sprintf("%f", coords.Lat),


### PR DESCRIPTION
While `osm` is a valid _alias_ when used in the `sources` parameter, all documents need to have `openstreetmap` as the source in order to be filtered properly.