### PR TITLE
Add more tags for selecting streets

### DIFF
--- a/command/crossroads.go
+++ b/command/crossroads.go
@@ -26,7 +26,7 @@ func Crossroads(c *cli.Context) error {
 
 	// stats handler
 	handler := &handler.Xroads{
-		TagWhiteList:   tags.Highway(),
+		TagWhiteList:   tags.Highway(c.Bool("path")),
 		WayNodesMask:   lib.NewBitMask(),
 		SharedNodeMask: lib.NewBitMask(),
 		WayNames:       make(map[int64]string),

--- a/command/crossroads.go
+++ b/command/crossroads.go
@@ -21,12 +21,22 @@ import (
 
 // Crossroads cli command
 func Crossroads(c *cli.Context) error {
+
+	var highwayTags = make(map[string]bool)
+	var cliHighwayTags = c.StringSlice("highway-tags")
+	if (len(cliHighwayTags)) > 0 {
+		for i := 0; i < len(cliHighwayTags); i++ {
+			highwayTags[cliHighwayTags[i]] = false
+		}
+	} else {
+		highwayTags = tags.Highway()
+	}
 	// create parser
 	parser := parser.NewParser(c.Args()[0])
 
 	// stats handler
 	handler := &handler.Xroads{
-		TagWhiteList:   tags.Highway(c.Bool("path")),
+		TagWhiteList:   highwayTags,
 		WayNodesMask:   lib.NewBitMask(),
 		SharedNodeMask: lib.NewBitMask(),
 		WayNames:       make(map[int64]string),

--- a/command/street_merge.go
+++ b/command/street_merge.go
@@ -30,7 +30,6 @@ type config struct {
 	Format          string
 	Delim           string
 	ExtendedColumns bool
-	highwayTags     bool
 }
 
 func (s *street) Print(conf *config) {
@@ -94,7 +93,6 @@ func StreetMerge(c *cli.Context) error {
 		Format:          "polyline",
 		Delim:           "\x00",
 		ExtendedColumns: c.Bool("extended"),
-		highwayTags:     false,
 	}
 	switch strings.ToLower(c.String("format")) {
 	case "geojson":
@@ -104,11 +102,6 @@ func StreetMerge(c *cli.Context) error {
 	}
 	if "" != c.String("delim") {
 		conf.Delim = c.String("delim")
-	}
-	if len(c.StringSlice("highway-tags")) > 0 {
-		conf.highwayTags = false
-	} else {
-		conf.highwayTags = true
 	}
 
 	// open sqlite database connection
@@ -384,7 +377,7 @@ func parsePBF(c *cli.Context, conn *sqlite.Connection) {
 	// create parser
 	parser := parser.NewParser(c.Args()[0])
 	var highwayTags = make(map[string]bool)
-	var cliHighwayTags = c.StringSlice("highway-tags")
+	var cliHighwayTags = strings.Split(c.String("highway-tags"), ",")
 	if (len(cliHighwayTags)) > 0 {
 		for i := 0; i < len(cliHighwayTags); i++ {
 			highwayTags[cliHighwayTags[i]] = false

--- a/command/street_merge.go
+++ b/command/street_merge.go
@@ -30,6 +30,7 @@ type config struct {
 	Format          string
 	Delim           string
 	ExtendedColumns bool
+	Path            bool
 }
 
 func (s *street) Print(conf *config) {
@@ -93,6 +94,7 @@ func StreetMerge(c *cli.Context) error {
 		Format:          "polyline",
 		Delim:           "\x00",
 		ExtendedColumns: c.Bool("extended"),
+		Path:            c.Bool("path"),
 	}
 	switch strings.ToLower(c.String("format")) {
 	case "geojson":
@@ -102,6 +104,11 @@ func StreetMerge(c *cli.Context) error {
 	}
 	if "" != c.String("delim") {
 		conf.Delim = c.String("delim")
+	}
+	if c.Bool("Path") != true {
+		conf.Path = false
+	} else {
+		conf.Path = true
 	}
 
 	// open sqlite database connection
@@ -113,7 +120,7 @@ func StreetMerge(c *cli.Context) error {
 	defer conn.Close()
 
 	// parse
-	parsePBF(c, conn)
+	parsePBF(c, conn, conf.Path)
 	var streets = generateStreetsFromWays(conn)
 	var joined = joinStreets(streets)
 
@@ -362,7 +369,7 @@ func generateStreetsFromWays(conn *sqlite.Connection) []*street {
 	return streets
 }
 
-func parsePBF(c *cli.Context, conn *sqlite.Connection) {
+func parsePBF(c *cli.Context, conn *sqlite.Connection, path bool) {
 
 	// validate args
 	var argv = c.Args()
@@ -379,7 +386,7 @@ func parsePBF(c *cli.Context, conn *sqlite.Connection) {
 
 	// streets handler
 	streets := &handler.Streets{
-		TagWhitelist: tags.Highway(),
+		TagWhitelist: tags.Highway(path),
 		NodeMask:     lib.NewBitMask(),
 		DBHandler:    DBHandler,
 	}

--- a/pbf.go
+++ b/pbf.go
@@ -117,7 +117,7 @@ func main() {
 			Name:  "xroads",
 			Usage: "compute street intersections",
 			Flags: []cli.Flag{
-				cli.StringSliceFlag{Name: "highway-tags", Usage: "use custom tags (default \"" + tags.HighwayTagsAsString() + "\")"},
+				cli.StringSliceFlag{Name: "highway-tags", Usage: "use custom highway tags", Value: &cli.StringSlice{tags.HighwayTagsAsString(), ""}},
 			},
 			Action: command.Crossroads,
 		},
@@ -128,7 +128,7 @@ func main() {
 				cli.StringFlag{Name: "format, f", Usage: "select output format, one of polyline/geojson/wkt"},
 				cli.StringFlag{Name: "delim, d", Usage: "change the column delimiter (default \x00)"},
 				cli.BoolFlag{Name: "extended, e", Usage: "output additional columns containing centroid and distance values"},
-				cli.StringFlag{Name: "highway-tags", Usage: "use custom tags (default \"" + tags.HighwayTagsAsString() + "\")"},
+				cli.StringSliceFlag{Name: "highway-tags", Usage: "use custom highway tags", Value: &cli.StringSlice{tags.HighwayTagsAsString(), ""}},
 			},
 			Action: command.StreetMerge,
 		},

--- a/pbf.go
+++ b/pbf.go
@@ -128,7 +128,7 @@ func main() {
 				cli.StringFlag{Name: "format, f", Usage: "select output format, one of polyline/geojson/wkt"},
 				cli.StringFlag{Name: "delim, d", Usage: "change the column delimiter (default \x00)"},
 				cli.BoolFlag{Name: "extended, e", Usage: "output additional columns containing centroid and distance values"},
-				cli.StringSliceFlag{Name: "highway-tags", Usage: "use custom tags (default \"" + tags.HighwayTagsAsString() + "\")"},
+				cli.StringFlag{Name: "highway-tags", Usage: "use custom tags (default \"" + tags.HighwayTagsAsString() + "\")"},
 			},
 			Action: command.StreetMerge,
 		},

--- a/pbf.go
+++ b/pbf.go
@@ -113,8 +113,11 @@ func main() {
 			Action: command.BoundaryExporter,
 		},
 		{
-			Name:   "xroads",
-			Usage:  "compute street intersections",
+			Name:  "xroads",
+			Usage: "compute street intersections",
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "path, p", Usage: "add paths to the list of allowed streets"},
+			},
 			Action: command.Crossroads,
 		},
 		{
@@ -124,6 +127,7 @@ func main() {
 				cli.StringFlag{Name: "format, f", Usage: "select output format, one of polyline/geojson/wkt"},
 				cli.StringFlag{Name: "delim, d", Usage: "change the column delimiter (default \x00)"},
 				cli.BoolFlag{Name: "extended, e", Usage: "output additional columns containing centroid and distance values"},
+				cli.BoolFlag{Name: "path, p", Usage: "add paths to the list of allowed streets"},
 			},
 			Action: command.StreetMerge,
 		},

--- a/pbf.go
+++ b/pbf.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/missinglink/pbf/command"
+	"github.com/missinglink/pbf/tags"
 	"github.com/urfave/cli"
 )
 
@@ -116,7 +117,7 @@ func main() {
 			Name:  "xroads",
 			Usage: "compute street intersections",
 			Flags: []cli.Flag{
-				cli.BoolFlag{Name: "path, p", Usage: "add paths to the list of allowed streets"},
+				cli.StringSliceFlag{Name: "highway-tags", Usage: "use custom tags (default \"" + tags.HighwayTagsAsString() + "\")"},
 			},
 			Action: command.Crossroads,
 		},
@@ -127,7 +128,7 @@ func main() {
 				cli.StringFlag{Name: "format, f", Usage: "select output format, one of polyline/geojson/wkt"},
 				cli.StringFlag{Name: "delim, d", Usage: "change the column delimiter (default \x00)"},
 				cli.BoolFlag{Name: "extended, e", Usage: "output additional columns containing centroid and distance values"},
-				cli.BoolFlag{Name: "path, p", Usage: "add paths to the list of allowed streets"},
+				cli.StringSliceFlag{Name: "highway-tags", Usage: "use custom tags (default \"" + tags.HighwayTagsAsString() + "\")"},
 			},
 			Action: command.StreetMerge,
 		},

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -78,5 +78,6 @@ func Highway() map[string]bool {
 	tags["pedestrian"] = false
 	tags["unclassified"] = false
 	tags["living_street"] = false
+	tags["track"] = false
 	return tags
 }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -1,5 +1,10 @@
 package tags
 
+import (
+	"sort"
+	"strings"
+)
+
 // Discardable tags
 // ref: http://wiki.openstreetmap.org/wiki/Discardable_tags
 // ref: https://github.com/openstreetmap/iD/blob/master/data/discarded.json
@@ -75,24 +80,15 @@ func Highway() map[string]bool {
 	tags["service"] = false
 	tags["tertiary"] = false
 	tags["road"] = false
-	tags["pedestrian"] = false
-	tags["unclassified"] = false
-	tags["living_street"] = false
-	tags["track"] = false
 	return tags
 }
 
 // Just a wrapper function to print the default highway tags in the help menu
 func HighwayTagsAsString() string {
-	var highwaySlice string
-	i := 0
+	var keys []string
 	for k := range Highway() {
-		if highwaySlice == "" {
-			highwaySlice += k
-		} else {
-			highwaySlice += "," + k
-		}
-		i++
+		keys = append(keys, k)
 	}
-	return highwaySlice
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
 }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -65,7 +65,7 @@ func Uninteresting() map[string]bool {
 }
 
 // Highway tags relevant for finding cross streets
-func Highway() map[string]bool {
+func Highway(path bool) map[string]bool {
 	tags := make(map[string]bool)
 	tags["motorway"] = false
 	tags["trunk"] = false
@@ -79,5 +79,8 @@ func Highway() map[string]bool {
 	tags["unclassified"] = false
 	tags["living_street"] = false
 	tags["track"] = false
+	if path {
+		tags["path"] = false
+	}
 	return tags
 }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -65,7 +65,7 @@ func Uninteresting() map[string]bool {
 }
 
 // Highway tags relevant for finding cross streets
-func Highway(path bool) map[string]bool {
+func Highway() map[string]bool {
 	tags := make(map[string]bool)
 	tags["motorway"] = false
 	tags["trunk"] = false
@@ -79,8 +79,20 @@ func Highway(path bool) map[string]bool {
 	tags["unclassified"] = false
 	tags["living_street"] = false
 	tags["track"] = false
-	if path {
-		tags["path"] = false
-	}
 	return tags
+}
+
+// Just a wrapper function to print the default highway tags in the help menu
+func HighwayTagsAsString() string {
+	var highwaySlice string
+	i := 0
+	for k := range Highway() {
+		if highwaySlice == "" {
+			highwaySlice += k
+		} else {
+			highwaySlice += "," + k
+		}
+		i++
+	}
+	return highwaySlice
 }

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -75,5 +75,8 @@ func Highway() map[string]bool {
 	tags["service"] = false
 	tags["tertiary"] = false
 	tags["road"] = false
+	tags["pedestrian"] = false
+	tags["unclassified"] = false
+	tags["living_street"] = false
 	return tags
 }

--- a/tags/tags_test.go
+++ b/tags/tags_test.go
@@ -20,7 +20,7 @@ func TestUninteresting(t *testing.T) {
 }
 
 func TestHighway(t *testing.T) {
-	var tagMap = Highway(true)
+	var tagMap = Highway()
 	assert.Equal(t, "map[string]bool", reflect.TypeOf(tagMap).String())
 	assert.True(t, len(tagMap) > 0)
 }

--- a/tags/tags_test.go
+++ b/tags/tags_test.go
@@ -20,7 +20,7 @@ func TestUninteresting(t *testing.T) {
 }
 
 func TestHighway(t *testing.T) {
-	var tagMap = Highway()
+	var tagMap = Highway(true)
 	assert.Equal(t, "map[string]bool", reflect.TypeOf(tagMap).String())
 	assert.True(t, len(tagMap) > 0)
 }


### PR DESCRIPTION
Basically a copy of #19 since this was abandoned. 

I added the tag `path` since "streets" like https://www.openstreetmap.org/way/5215288 or https://www.openstreetmap.org/way/319837352. I'm not quite sure about this tag, because it cause a lot of noise by external bicycle lanes, etc.
Overpass query for example in munich: https://overpass-turbo.eu/s/1rJ0