### PR TITLE
[docs] Add install command for recent versions of go

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,11 @@ utilities for parsing OpenStreetMap PBF files and extracting geographic data
 
 > tested on go version go1.9, recommended go1.10, cross-compilation possibly broken in recent versions of go
 
+go1.17 and above
+```bash
+$ go install github.com/missinglink/pbf@latest
+```
+below go1.16
 ```bash
 $ export GO111MODULE=on
 $ go get github.com/missinglink/pbf

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ go1.17 and above
 ```bash
 $ go install github.com/missinglink/pbf@latest
 ```
-below go1.16
+below go1.17
 ```bash
 $ export GO111MODULE=on
 $ go get github.com/missinglink/pbf


### PR DESCRIPTION
Just a minor update in the readme. Since go1.16 the export command is not required, since this is on by default. https://tip.golang.org/doc/go1.16#modules
And go1.17 moves the `go get` command to `go install` for binaries. https://go.dev/doc/go-get-install-deprecation

I left the old instruction untouched, since g1.10 is recommanded.