### PR TITLE
Support for custom highway tags

### DIFF
--- a/command/crossroads.go
+++ b/command/crossroads.go
@@ -26,7 +26,7 @@ func Crossroads(c *cli.Context) error {
 
 	// stats handler
 	handler := &handler.Xroads{
-		TagWhiteList:   tags.Highway(),
+		TagWhiteList:   tags.FromString(c.String("highway-tags")),
 		WayNodesMask:   lib.NewBitMask(),
 		SharedNodeMask: lib.NewBitMask(),
 		WayNames:       make(map[int64]string),

--- a/command/street_merge.go
+++ b/command/street_merge.go
@@ -379,7 +379,7 @@ func parsePBF(c *cli.Context, conn *sqlite.Connection) {
 
 	// streets handler
 	streets := &handler.Streets{
-		TagWhitelist: tags.Highway(),
+		TagWhitelist: tags.FromString(c.String("highway-tags")),
 		NodeMask:     lib.NewBitMask(),
 		DBHandler:    DBHandler,
 	}

--- a/pbf.go
+++ b/pbf.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/missinglink/pbf/command"
+	"github.com/missinglink/pbf/tags"
 	"github.com/urfave/cli"
 )
 
@@ -113,8 +114,11 @@ func main() {
 			Action: command.BoundaryExporter,
 		},
 		{
-			Name:   "xroads",
-			Usage:  "compute street intersections",
+			Name:  "xroads",
+			Usage: "compute street intersections",
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "highway-tags", Usage: "custom highway tags", Value: tags.ToString(tags.Highway())},
+			},
 			Action: command.Crossroads,
 		},
 		{
@@ -124,6 +128,7 @@ func main() {
 				cli.StringFlag{Name: "format, f", Usage: "select output format, one of polyline/geojson/wkt"},
 				cli.StringFlag{Name: "delim, d", Usage: "change the column delimiter (default \x00)"},
 				cli.BoolFlag{Name: "extended, e", Usage: "output additional columns containing centroid and distance values"},
+				cli.StringFlag{Name: "highway-tags", Usage: "custom highway tags", Value: tags.ToString(tags.Highway())},
 			},
 			Action: command.StreetMerge,
 		},

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -1,5 +1,10 @@
 package tags
 
+import (
+	"sort"
+	"strings"
+)
+
 // Discardable tags
 // ref: http://wiki.openstreetmap.org/wiki/Discardable_tags
 // ref: https://github.com/openstreetmap/iD/blob/master/data/discarded.json
@@ -76,4 +81,33 @@ func Highway() map[string]bool {
 	tags["tertiary"] = false
 	tags["road"] = false
 	return tags
+}
+
+func FromSlice(strings []string) map[string]bool {
+	var tags = make(map[string]bool, len(strings))
+	for _, t := range strings {
+		tags[t] = false
+	}
+	return tags
+}
+
+func ToSlice(tags map[string]bool) []string {
+	var keys []string
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func FromString(str string) map[string]bool {
+	var keys = strings.Split(str, ",")
+	for i := range keys {
+		keys[i] = strings.TrimSpace(keys[i])
+	}
+	return FromSlice(keys)
+}
+
+func ToString(tags map[string]bool) string {
+	return strings.Join(ToSlice(tags), ",")
 }


### PR DESCRIPTION
This PR modifies the `xroads` & `streets` commands by adding an additional CLI flag named `--highway-tags`.

This tag allows user to override the default hard-coded internal highway tag list.

Usage information is available on the command-line, which will also list the default tags for reference:

```bash
go run pbf.go xroads --help
NAME:
   pbf xroads - compute street intersections

USAGE:
   pbf xroads [command options] [arguments...]

OPTIONS:
   --highway-tags value  custom highway tags (default: "motorway,primary,residential,road,secondary,service,tertiary,trunk")
```

The tags can be supplied as a single comma-delimited string:

```bash
go run pbf.go xroads --highway-tags 'foo,bar' /data/osm/data.osm.pbf
map[bar:false foo:false]
```

resolves https://github.com/missinglink/pbf/pull/33